### PR TITLE
Add dummy NODE_CLASS_MAPPINGS in __init__.py

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -7,6 +7,7 @@ import __main__
 
 python = sys.executable
 
+NODE_CLASS_MAPPINGS = {}
 
 extentions_folder = os.path.join(os.path.dirname(os.path.realpath(__main__.__file__)),
                                  "web" + os.sep + "extensions" + os.sep + "ZZZ-Bmad-DirtyUndoRedo")


### PR DESCRIPTION
It looks ComfyUI requires `NODE_CLASS_MAPPINGS` constant.
I got following warning.

```python
Bmad-DirtyUndoRedo Loaded.
Skip /data/ComfyUI/custom_nodes/ComfyUI-Bmad-DirtyUndoRedo module for custom nodes due to the lack of NODE_CLASS_MAPPINGS.
```

So, I added a dummy constant in `__init__.py`.
After that, warning is surpressed.

```
Import times for custom nodes:
...
   0.0 seconds: /data/ComfyUI/custom_nodes/ComfyUI_Dave_CustomNode
... 
``
